### PR TITLE
Changed package used to read in stata files

### DIFF
--- a/R/queryAlspac.R
+++ b/R/queryAlspac.R
@@ -424,7 +424,7 @@ extractVarsFull <- function(x)
 			message("Skipping...")
 			return(NULL)
 		}
-		obj <- suppressWarnings(readstata13::read.dta13(fn))
+    obj <- suppressWarnings(haven::read_dta(fn))
 
 		# Make sure aln and qlet variables are lower case
 		alnc <- grep("^ALN$", names(obj), ignore.case=TRUE)


### PR DESCRIPTION
readstata13 loses information when reading in .dta files because it ignores all the comments on the variables. This is a pain with alspac data because it means you have no idea what the variables correspond to because each of the column names aren't descriptions of the variables, e.g. the column "fm4ms100" is actually height measured at the FOM4 time point... 